### PR TITLE
Turn update-cli script into a monstrosity

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# A trivial test harness
+# - Just run each of the files named test_ in a subdirectory specified
+# - NOTE: The name of the subdirectory should be the filename of the app to be tested
+#
+testsDir=$(cd $(dirname $0); pwd)
+
+source $testsDir/utils.sh
+
+if [ 0 = $# ]; then
+    echo "Usage: $0 testsuite_dir [testsuite_dir ...]"
+    echo "       Note: testsuite_dir should be the same filename as the app to be tested."
+    exit 1
+fi
+
+echo "Performing tests on: $*"
+
+overall_status=0
+for d in $*; do
+    echo "Running tests in $d"
+    if [ ! -d $d ]; then echo "Not a test directory: $d"; exit 1; fi
+    err_count=0
+
+    for i in $d/test_* ; do
+        echo "${i}:"
+        mk_tmpfile
+        $i > $tmpfile 2>&1
+        err=$?
+        if [ 0 -ne $err ]; then
+            echo "FAILED: $i. Output in: $tmpfile"
+            err_count=$((err_count + 1))
+            overall_status=$((overall_status + 1))
+        else
+            rm $tmpfile
+        fi
+    done
+
+    if [ 0 -eq $err_count ]; then
+        echo "Succeeded."
+        # exit 0
+    else
+        echo "Failed with $err_count errors."
+        # exit $err_count
+    fi
+done
+
+echo ; echo 
+if [ 0 -eq $overall_status ]; then
+    echo "OVERALL: Succeded!"
+    exit 0
+else
+    echo "OVERALL: Failed with $overall_status errors."
+    exit $overall_status
+fi
+
+    

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -14,7 +14,7 @@ if [ 0 = $# ]; then
     exit 1
 fi
 
-echo "Performing tests on: $*"
+echo "Performing tests on: $*" ; echo
 
 overall_status=0
 for d in $*; do
@@ -23,7 +23,7 @@ for d in $*; do
     err_count=0
 
     for i in $d/test_* ; do
-        echo "${i}:"
+        echo "- ${i}"
         mk_tmpfile
         $i > $tmpfile 2>&1
         err=$?

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -47,7 +47,7 @@ done
 
 echo ; echo 
 if [ 0 -eq $overall_status ]; then
-    echo "OVERALL: Succeded!"
+    echo "OVERALL: Succeeded!"
     exit 0
 else
     echo "OVERALL: Failed with $overall_status errors."

--- a/tests/tests/test_null_test.sh
+++ b/tests/tests/test_null_test.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env true

--- a/tests/tests/test_stdout.sh
+++ b/tests/tests/test_stdout.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "Sample stdout"
+
+exit 0
+

--- a/tests/tests_fail/test_fail.sh
+++ b/tests/tests_fail/test_fail.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env false

--- a/tests/tests_fail/test_stderr.sh
+++ b/tests/tests_fail/test_stderr.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+perl -e "print STDERR 'This is some error output'"
+
+exit -1
+

--- a/tests/update-cli.sh/test_404.sh
+++ b/tests/update-cli.sh/test_404.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is $tmpdir"
+
+${binDir}/$bin -xp $tmpdir -u file://not-there
+
+# We'll never need to inspect the tmpdir
+rm -r $tmpdir
+
+if [ 0 -ne $? ]; then
+    exit 0;
+else
+    echo "FAILED: Expected non-zero exit code."
+fi

--- a/tests/update-cli.sh/test_append_build.sh
+++ b/tests/update-cli.sh/test_append_build.sh
@@ -12,8 +12,8 @@ source $parentDir/utils.sh
 prep_tmpdir
 echo "tmpdir is: $tmpdir"
 
-${binDir}/$bin -x -c ltc -p $tmpdir
-${binDir}/$bin -x -c cf -p $tmpdir
+${binDir}/$bin -x -c ltc -p $tmpdir -r edge
+${binDir}/$bin -x -c cf -p $tmpdir -r edge
 
 failCount=0
 # There should be one link pointing to a file with the cli-ver-buildno format

--- a/tests/update-cli.sh/test_append_build.sh
+++ b/tests/update-cli.sh/test_append_build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -x
+#
+# Per feature request, should save files that include the version and build number in the bindir
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is: $tmpdir"
+
+${binDir}/$bin -x -c ltc -p $tmpdir
+${binDir}/$bin -x -c cf -p $tmpdir
+
+failCount=0
+# There should be one link pointing to a file with the cli-ver-buildno format
+ltcbin=$(readlink $tmpdir/ltc) 
+echo $ltcbin | egrep -q -e 'ltc-v[\.0-9]*-[0-9]*$'
+if [ 0 -ne $? ]; then
+    echo "FAILED: ltc link ($ltcbin) does not point to a binary including build number"
+    failCount=$((failCount + 1))
+fi
+
+# There should be one link pointing to a file with the cli-ver-SHA format
+cfbin=$(readlink $tmpdir/cf) 
+echo $cfbin | egrep -q -e 'cf-([.[:digit:]]+)-([[:alnum:]]+)$'
+
+if [ 0 -ne $? ]; then
+    echo "FAILED: cf link ($cfbin) does not point to a binary including build SHA"
+    failCount=$((failCount + 1))
+fi
+if [ 0 -eq $failCount ]; then
+    rm -r $tmpdir
+    exit 0
+else
+    echo "FAILED with $failCount errors"
+    exit $failCount
+fi
+
+    

--- a/tests/update-cli.sh/test_bindir_dne.sh
+++ b/tests/update-cli.sh/test_bindir_dne.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+#
+# Default test - does it do the right thing if the bin dir does not exist?
 
 testsDir=$(cd $(dirname $0); pwd)
 bin=$(basename $testsDir)
@@ -8,17 +10,16 @@ binDir=${parentDir%/*}
 source $parentDir/utils.sh
 
 prep_tmpdir
-echo "tmpdir is $tmpdir"
+echo "tmpdir is: $tmpdir"
 
-${binDir}/$bin -xp $tmpdir -u file://not-there
+${binDir}/$bin -x -c ltc -p /tmp/THIS_DIRECTORY_DOES_NOT_EXIST.$$
 
 exit_code=$?
-echo "Exit code: $exit_code"
 
 # We'll never need to inspect the tmpdir
 rm -r $tmpdir
 
-if [ 0 -eq $? ]; then
+if [ 0 -ne $exit_code ]; then
     exit 0;
 else
     echo "FAILED: Expected non-zero exit code."

--- a/tests/update-cli.sh/test_clean_cf.sh
+++ b/tests/update-cli.sh/test_clean_cf.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Default test - does it do the right thing with an empty directory?
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is: $tmpdir"
+
+${binDir}/$bin -x -p $tmpdir
+
+failCount=0
+# There should be one link, one binary.
+c=0
+for i in ${tmpdir}/*; do c=$((c + 1)); done
+
+if [ $c -ne 2 ]; then
+    echo "FAILED: incorrect number of files in tmp bindir"
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -L ${tmpdir}/cf ]; then
+    echo "FAILED: no cf link."
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -f ${tmpdir}/cf-* ]; then
+    echo "FAILED: no binary file."
+    failCount=$((failCount + 1))
+fi
+
+if [ 0 -eq $failCount ]; then
+    rm -r $tmpdir
+    exit 0
+else
+    echo "FAILED with $failCount errors"
+    exit $failCount
+fi
+
+    

--- a/tests/update-cli.sh/test_clean_ltc.sh
+++ b/tests/update-cli.sh/test_clean_ltc.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Default test - does it do the right thing with an empty directory?
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is: $tmpdir"
+
+${binDir}/$bin -x -c ltc -p $tmpdir
+
+failCount=0
+# There should be one link, one binary.
+c=0
+for i in ${tmpdir}/*; do c=$((c + 1)); done
+
+if [ $c -ne 2 ]; then
+    echo "FAILED: incorrect number of files in tmp bindir"
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -L ${tmpdir}/ltc ]; then
+    echo "FAILED: no ltc link."
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -f ${tmpdir}/ltc-* ]; then
+    echo "FAILED: no binary file."
+    failCount=$((failCount + 1))
+fi
+
+if [ 0 -eq $failCount ]; then
+    rm -r $tmpdir
+    exit 0
+else
+    echo "FAILED with $failCount errors"
+    exit $failCount
+fi
+
+    

--- a/tests/update-cli.sh/test_existing_bin.sh
+++ b/tests/update-cli.sh/test_existing_bin.sh
@@ -35,7 +35,7 @@ if [ ! -L ${tmpdir}/cf.old ]; then
     failCount=$((failCount + 1))
 fi
 
-if [ ! -f ${tmpdir}/cf-0.0.1 ]; then
+if [ ! -f ${tmpdir}/cf-0.0.1* ]; then
     echo "FAILED: no old binary file."
     failCount=$((failCount + 1))
 fi

--- a/tests/update-cli.sh/test_existing_bin.sh
+++ b/tests/update-cli.sh/test_existing_bin.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Does it do the right thing if a binary already exists in the target dir?
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is: $tmpdir"
+
+cat > ${tmpdir}/cf <<-EOF
+	#!/bin/sh
+	echo "cf fake version 0.0.1-abcde"
+EOF
+chmod +x ${tmpdir}/cf
+
+${binDir}/$bin -x -p $tmpdir
+
+failCount=0
+# There should be two links, two binaries
+c=0
+for i in ${tmpdir}/*; do c=$((c + 1)); done
+
+if [ $c -ne 4 ]; then
+    echo "FAILED: incorrect number of files in tmp bindir"
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -L ${tmpdir}/cf.old ]; then
+    echo "FAILED: no cf link."
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -f ${tmpdir}/cf-0.0.1 ]; then
+    echo "FAILED: no old binary file."
+    failCount=$((failCount + 1))
+fi
+
+if [ 0 -eq $failCount ]; then
+    rm -r $tmpdir
+    exit 0
+else
+    echo "FAILED with $failCount errors"
+    exit $failCount
+fi
+
+    

--- a/tests/update-cli.sh/test_existing_link.sh
+++ b/tests/update-cli.sh/test_existing_link.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Does it do the right thing if a link to a binary already exists?
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is: $tmpdir"
+
+cat > ${tmpdir}/cf-0.0.1 <<-EOF
+	#!/bin/sh
+	echo "cf fake version 0.0.1-abcde"
+EOF
+chmod +x ${tmpdir}/cf-0.0.1
+ln -s ${tmpdir}/cf-0.0.1 ${tmpdir}/cf
+
+${binDir}/$bin -x -p $tmpdir
+
+failCount=0
+# There should be two links, two binaries
+c=0
+for i in ${tmpdir}/*; do c=$((c + 1)); done
+
+if [ $c -ne 4 ]; then
+    echo "FAILED: incorrect number of files in tmp bindir"
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -L ${tmpdir}/cf.old ]; then
+    echo "FAILED: no cf link."
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -f ${tmpdir}/cf-0.0.1 ]; then
+    echo "FAILED: no old binary file."
+    failCount=$((failCount + 1))
+fi
+
+if [ 0 -eq $failCount ]; then
+    rm -r $tmpdir
+    exit 0
+else
+    echo "FAILED with $failCount errors"
+    exit $failCount
+fi
+
+    

--- a/tests/update-cli.sh/test_existing_version.sh
+++ b/tests/update-cli.sh/test_existing_version.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# This is a tricky one:
+# Does it replace the existing binary if the new downloaded binary is the same version?
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is: $tmpdir"
+
+# Not a typo. Run the program twice.
+${binDir}/$bin -x -p $tmpdir
+${binDir}/$bin -x -p $tmpdir
+
+failCount=0
+# There should be one link, one binary
+c=0
+for i in ${tmpdir}/*; do c=$((c + 1)); done
+
+if [ $c -ne 2 ]; then
+    echo "FAILED: incorrect number of files in tmp bindir"
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -L ${tmpdir}/cf ]; then
+    echo "FAILED: no cf link."
+    failCount=$((failCount + 1))
+fi
+
+if [ ! -f ${tmpdir}/cf-* ]; then
+    echo "FAILED: no binary file."
+    failCount=$((failCount + 1))
+fi
+
+if [ 0 -eq $failCount ]; then
+    rm -r $tmpdir
+    exit 0
+else
+    echo "FAILED with $failCount errors"
+    exit $failCount
+fi
+
+    

--- a/tests/update-cli.sh/test_stable_ver.sh
+++ b/tests/update-cli.sh/test_stable_ver.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -x
+#
+# update-cli contains code to d/l unstable versions of the cli, which are indicated by a build number or SHA. When downloading a stable release, update-cli shouldn't append the build
+
+testsDir=$(cd $(dirname $0); pwd)
+bin=$(basename $testsDir)
+parentDir=${testsDir%/*}
+binDir=${parentDir%/*}
+
+source $parentDir/utils.sh
+
+prep_tmpdir
+echo "tmpdir is: $tmpdir"
+
+${binDir}/$bin -x -c ltc -p $tmpdir -r stable
+${binDir}/$bin -x -c cf -p $tmpdir -r stable
+
+failCount=0
+# There should be one link pointing to a file with the cli-ver format
+ltcbin=$(readlink $tmpdir/ltc) 
+echo $ltcbin | egrep -q -e 'ltc-v[\.0-9]*$'
+if [ 0 -ne $? ]; then
+    echo "FAILED: ltc link ($ltcbin) does not point to a filename that uses only the version number."
+    failCount=$((failCount + 1))
+fi
+
+# There should be one link pointing to a file with the cli-ver-SHA format
+cfbin=$(readlink $tmpdir/cf) 
+echo $cfbin | egrep -q -e 'cf-([.[:digit:]]+)$'
+
+if [ 0 -ne $? ]; then
+    echo "FAILED: cf link ($cfbin) does not point to a filename that uses only the version number."
+    failCount=$((failCount + 1))
+fi
+if [ 0 -eq $failCount ]; then
+    rm -r $tmpdir
+    exit 0
+else
+    echo "FAILED with $failCount errors"
+    exit $failCount
+fi
+
+    

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -1,0 +1,24 @@
+#
+# Utility functions for a tiny test framework - Marco N. 6/18/15
+#
+date_string () {
+    datestr=$(date "+%m-%d-%Y_%H:%M:%S")
+    if [ ! $? ]; then echo "ERROR: Failed to get datetime"; exit 1; fi
+}
+
+stringP () {
+    if [ -z $1 ]; then $?=0; else $?=1; fi
+}
+
+prep_tmpdir () {
+    date_string ;
+    tmpdir="/tmp/tests_${datestr}_$$"
+    mkdir $tmpdir
+}
+
+mk_tmpfile () {
+    date_string ;
+    tmpfile="/tmp/tests_${datestr}_$$.t"
+    if [ -e $tmpfile ]; then rm $tmpfile; fi
+    touch $tmpfile
+}

--- a/update-cli.sh
+++ b/update-cli.sh
@@ -93,13 +93,13 @@ relink () {
         # This is a new version, so replace any .old with the current binary
         if [ -e ${bindir}/${cli}.old ] ; then rm $bindir/${cli}.old; fi
         if [ ! -L ${bindir}/$cli ] ; then
-            if [ "$cur_build"X -ne != "N/AX" ]; then
+            if [ "$cur_build"X != "N/AX" ]; then
                 mv ${bindir}/$cli ${bindir}/${cli}-$cur_version-$cur_build
             else
                 mv ${bindir}/$cli ${bindir}/${cli}-$cur_version
             fi
         fi
-        if [ "$cur_build"X -ne != "N/AX" ]; then
+        if [ "$cur_build"X != "N/AX" ]; then
             ln -s $bindir/${cli}-$cur_version-$cur_build $bindir/${cli}.old
         else
             ln -s $bindir/${cli}-$cur_version $bindir/${cli}.old
@@ -111,7 +111,7 @@ relink () {
 
     # If there's a pre-existing bin that's not a link, move it aside
     if [ -e ${bindir}/$cli -a ! -L ${bindir}/$cli ]; then
-        if [ "$cur_build"X -ne "N/AX" ]; then
+        if [ "$cur_build"X != "N/AX" ]; then
             mv ${bindir}/$cli ${bindir}/${cli}-$cur_version-$cur_build;
         else
             mv ${bindir}/$cli ${bindir}/${cli}-$cur_version

--- a/update-cli.sh
+++ b/update-cli.sh
@@ -64,8 +64,10 @@ windows_BOSH=("/bin/false" "/bin/false")
 getver () {
     if [ -e ${1}/$2 ]; then
         current_ver=`${1}/$2 -v`
-        short=${current_ver##*$2*version }
-        version=${short/-*}
+        version=$(echo $current_ver | sed 's/.*version \([v0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+        build=$(echo $current_ver | sed 's/.*version [v0-9]*\.[0-9]*\.[0-9]*-*\([^ ]*\).*/\1/')
+        # short=${current_ver##*$2*version }
+        # version=${short/-*}
     else
         version="N/A"
     fi
@@ -149,6 +151,11 @@ for i ; do
             shift ; break ;;
     esac
 done    
+
+if [ ! -e $bindir ]; then
+    echo "ERROR: Target directory does not exist."
+    exit 1
+fi
 
 if [ ! -z $alt_url ]; then
     cli_uri=$alt_url

--- a/update-cli.sh
+++ b/update-cli.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# I hate to use bash, but I want to use arrays for stable/unstable URLs
+
+# DEFAULTS
+cli="cf"
+rel=1
+bindir="/usr/local/bin"
+alt_url=""
+
+usage="\
+$0  Download and update a new version of a binary.
+
+    Overwrites binaries that have the same semantic version (ie, new
+    builds of the same release). Symlinks the binary name to the
+    version requested (stable or edge). If the fresh binary is a new
+    version, this script will symlink the currently installed version
+    to [binary].old.
+
+Options:
+    -h                This help
+    -c cli            Specify cf or ltc (or bosh) CLI (defaults to unstable release)
+    -r stable|edge    Specify stable (release) or edge (unstable) release
+    -p bindir         Specify the target directory to install the binary
+                      (Defaults to: $bindir)
+    -u url            Override binary URL
+    -x                Debug mode
+    -v                Print version
+"
+
+## Changelog
+# Added a hint to give BOSH some love
+# Added an -u option to override the URL used to d/l the cli
+#   (Useful if you need a specific version rather than stable/unstable)
+# Added a -v to print current version
+# Clean up cf tar in /tmp, and empty /tmp file if curl fails
+# Knows URIs for cf and ltc binaries
+# Allows user to specify stable or edge
+# Now saves previous semvers as .old, overwrites new builds of current semver
+# Logic to make filenames include semver and symlink binary and binary.old
+# Used $OSTYPE to auto-choose correct version # FIXME: Windows??
+# Added getopt to process command line args, also usage help text
+# Switched from wget to curl, since OSX doesn't ship with wget
+# When downloading CF, identify source as "internal" (vs github)
+
+version="0.0.3"
+
+# Format is OS_CLI(Release Unstable)
+darwin_CF=("https://cli.run.pivotal.io/stable?release=macosx64-binary&source=internal" "https://cli.run.pivotal.io/edge?arch=macosx64&source=internal")
+# Assuming 64 bit versions only
+linux_CF=("https://cli.run.pivotal.io/stable?release=linux64-binary&source=internal" "https://cli.run.pivotal.io/edge?arch=linux64&source=internal")
+windows_CF=("https://cli.run.pivotal.io/stable?release=windows64-exe&source=internal" "https://cli.run.pivotal.io/edge?arch=windows64&source=internal")
+#
+darwin_LTC=("https://lattice.s3.amazonaws.com/releases/latest/darwin-amd64/ltc" "https://lattice.s3.amazonaws.com/unstable/latest/darwin-amd64/ltc")
+linux_LTC=("https://lattice.s3.amazonaws.com/releases/latest/linux-amd64/ltc" "https://lattice.s3.amazonaws.com/unstable/latest/linux-amd64/ltc")
+windows_LTC=("/bin/false" "/bin/false")
+#
+darwin_BOSH=("/bin/false" "/bin/false")
+linux_BOSH=("/bin/false" "/bin/false")
+windows_BOSH=("/bin/false" "/bin/false")
+
+####
+
+# Call like this: getver dir binary
+getver () {
+    if [ -e ${1}/$2 ]; then
+        current_ver=`${1}/$2 -v`
+        short=${current_ver##*$2*version }
+        version=${short/-*}
+    else
+        version="N/A"
+    fi
+}
+
+download () {
+    curl -sL $1 > /tmp/$2-$$.bin
+    if [ 0 -ne $? ]; then
+        rm /tmp/$2-$$.bin
+        echo "Error downloading $2. Aborting."
+        exit -1
+    fi
+}
+
+relink () {
+    if [ "$cur_version"X != "N/AX" -a "$cur_version"X != "$new_version"X ] ; then
+        # If new version, overwrite any .old.
+        if [ ! -L ${bindir}/$cli ] ; then 
+            mv ${bindir}/$cli ${bindir}/${cli}-$cur_version
+        fi
+        if [ -e ${bindir}/${cli}.old ] ; then rm $bindir/${cli}.old; fi
+        ln -s $bindir/${cli}-$cur_version $bindir/${cli}.old
+        old_version=$cur_version
+    fi
+    
+    if [ -e ${bindir}/$cli -a ! -L ${bindir}/$cli ]; then mv ${bindir}/$cli ${bindir}/${cli}-$cur_version; fi
+    if [ -e ${bindir}/$cli ] ; then rm ${bindir}/$cli; fi
+    mv $cli ${bindir}/${cli}-$new_version
+    ln -s ${bindir}/${cli}-$new_version ${bindir}/$cli
+}
+
+args=`getopt vxnhr:c:p:u: $*`; errcode=$?; set -- $args
+if [ 0 -ne $errcode ]; then echo ; echo "$usage" ; exit $errcode ; fi
+
+for i ; do
+    case $i in
+        -v)
+            echo $version
+            exit 0
+            ;;
+        -h)
+            echo "$usage"
+            exit 0 ;;
+        -x)
+            echo "Debug mode."
+            set -x ; shift ;;
+        -r)
+            case "$2" in
+                release|stable)
+                    rel=0 ;;
+                edge|unstable)
+                    rel=1 ;;
+                *)
+                    echo "Error: release must be stable or edge."
+                    exit 1
+                    ;;
+            esac
+            shift; shift ;;
+        -c)
+            case "$2" in
+                cf)
+                    cli="cf" ;;
+                ltc)
+                    cli="ltc" ;;
+                bosh)
+                    echo "BOSH not implemented yet! (hint hint)"
+                    exit 0 ;;
+                *)
+                    echo "Error: cli must be either cf or ltc."
+                    exit 1
+                    ;;
+            esac
+            shift ; shift ;;
+        -p)
+            bindir="$2"
+            shift ; shift ;;
+        -u)
+            alt_url="$2" ;
+            shift ; shift ;;
+        --)
+            shift ; break ;;
+    esac
+done    
+
+if [ ! -z $alt_url ]; then
+    cli_uri=$alt_url
+else
+    case $OSTYPE in
+        darwin*)
+            os="darwin"
+            if [ "cf" == $cli ] ; then cli_uri=${darwin_CF[rel]}; fi
+            if [ "ltc" == $cli ] ; then cli_uri=${darwin_LTC[rel]}; fi
+            ;;
+        linux*)
+            os="linux"
+            if [ "cf" == $cli ] ; then cli_uri=${linux_CF[rel]}; fi
+            if [ "ltc" == $cli ] ; then cli_url=${linux_LTC[rel]}; fi
+            ;;
+        *)
+            os="windows"
+            if [ "cf" == $cli ] ; then cli_uri=${linux_CF[rel]}; fi
+            if [ "ltc" == $cli ] ; then echo "Windows not supported."; exit 1; fi
+    esac
+fi
+
+# Save off old version, if any
+if [ -e $bindir/${cli}.old ] ; then
+    getver $bindir ${cli}.old
+    old_version=$version
+else
+    old_version="N/A"
+fi
+    
+echo "Downloading $cli_uri"
+cd /tmp
+case $cli in
+    cf)
+        getver ${bindir} cf
+        cur_version=$version
+        download $cli_uri $cli
+        tar xf cf-$$.bin
+        rm cf-$$.bin
+        getver . cf
+        new_version=$version
+        ;;
+    ltc)
+        getver ${bindir} ltc
+        cur_version=$version
+        download $cli_uri $cli
+        mv $cli-$$.bin $cli
+        chmod a+rx $cli
+        getver . ltc
+        new_version=$version
+        ;;
+    bosh)
+        ;;
+esac
+
+echo "Installing in $bindir"
+relink
+
+if [ "$old_version"X != "N/AX" ]; then echo "Old: ${old_version}: ${bindir}/${cli}.old"; fi
+echo "New: ${new_version}: ${bindir}/${cli}"

--- a/update-go-cli.sh
+++ b/update-go-cli.sh
@@ -1,178 +1,25 @@
 #! /bin/bash
 
-# DEFAULTS
-cli="cf"
-rel=1
-bindir="/usr/local/bin"
+old_version=`cf -v`
 
-usage="\
-$0  Download and update a new version of a binary.
+echo 'Downloading latest edge'
+wget http://go-cli.s3.amazonaws.com/master/cf-darwin-amd64.tgz
 
-    Overwrites binaries that have the same semantic version (ie, new
-    builds of the same release). Symlinks the binary name to the
-    version requested (stable or edge). If the fresh binary is a new
-    version, this script will symlink the currently installed version
-    to [binary].old.
+#echo 'Downloading latest stable'
+#wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-darwin-amd64.tgz
 
-Options:
-    -h                This help
-    -c cf|ltc         Specify cf or ltc CLI (defaults to unstable release)
-    -r stable|edge    Specify stable (release) or edge (unstable) release
-    -p bindir         Specify the target directory to install the binary
-                      (Defaults to: $bindir)
-    -x                Debug mode
-"
+echo 'Uncompressing...'
+tar -xf cf-darwin-amd64.tgz
 
-## Changelog
-# Knows URIs for cf and ltc binaries
-# Allows user to specify stable or edge
-# Now saves previous semvers as .old, overwrites new builds of current semver
-# Logic to make filenames include semver and symlink binary and binary.old
-# Used $OSTYPE to auto-choose correct version # FIXME: Windows??
-# Added getopt to process command line args, also usage help text
-# Switched from wget to curl, since OSX doesn't ship with wget
-# When downloading CF, identify source as "internal" (vs github)
+echo 'Moving binary to /usr/local/bin/cf'
+mv cf /usr/local/bin/cf
 
-# Format is OS_CLI(Release Unstable)
-darwin_CF=("https://cli.run.pivotal.io/stable?release=macosx64-binary&source=internal" "https://cli.run.pivotal.io/edge?arch=macosx64&source=internal")
-# Assuming 64 bit versions only
-linux_CF=("https://cli.run.pivotal.io/stable?release=linux64-binary&source=internal" "https://cli.run.pivotal.io/edge?arch=linux64&source=internal")
-windows_CF=("https://cli.run.pivotal.io/stable?release=windows64-exe&source=internal" "https://cli.run.pivotal.io/edge?arch=windows64&source=internal")
-#
-darwin_LTC=("https://lattice.s3.amazonaws.com/releases/latest/darwin-amd64/ltc" "https://lattice.s3.amazonaws.com/unstable/latest/darwin-amd64/ltc")
-linux_LTC=("https://lattice.s3.amazonaws.com/releases/latest/linux-amd64/ltc" "https://lattice.s3.amazonaws.com/unstable/latest/linux-amd64/ltc")
-windows_LTC=("/bin/false" "/bin/false")
+echo 'Deleting tarball'
+rm cf-darwin-amd64.tgz
 
-####
+echo ' '
+printf "Previous Version:  "
+echo $old_version
 
-# Call like this: getver dir binary
-getver () {
-    if [ -e ${1}/$2 ]; then
-        current_ver=`${1}/$2 -v`
-        short=${current_ver##*$2 version }
-        version=${short/-*}
-    else
-        version="N/A"
-    fi
-}
-
-download () {
-    curl -sL $1 > /tmp/$2-$$.bin
-    if [ 0 -ne $? ]; then
-        echo "Error downloading CLI. Aborting."
-        exit -1
-    fi
-}
-
-relink () {
-    if [ "$cur_version"X != "N/AX" -a "$cur_version"X != "$new_version"X ] ; then
-        # If new version, overwrite any .old.
-        if [ ! -L ${bindir}/$cli ] ; then 
-            mv ${bindir}/$cli ${bindir}/${cli}-$cur_version
-        fi
-        if [ -e ${bindir}/${cli}.old ] ; then rm $bindir/${cli}.old; fi
-        ln -s $bindir/${cli}-$cur_version $bindir/${cli}.old
-        old_version=$cur_version
-    fi
-    
-    if [ -e ${bindir}/$cli -a ! -L ${bindir}/$cli ]; then mv ${bindir}/$cli ${bindir}/${cli}-$cur_version; fi
-    if [ -e ${bindir}/$cli ] ; then rm ${bindir}/$cli; fi
-    mv $cli ${bindir}/${cli}-$new_version
-    ln -s ${bindir}/${cli}-$new_version ${bindir}/$cli
-}
-
-args=`getopt xnhr:c:p: $*`; errcode=$?; set -- $args
-if [ 0 -ne $errcode ]; then echo ; echo "$usage" ; exit $errcode ; fi
-
-for i ; do
-    case $i in
-        -h)
-            echo "$usage"
-            exit 0 ;;
-        -x)
-            echo "Debug mode."
-            set -x ; shift ;;
-        -r)
-            case "$2" in
-                release|stable)
-                    rel=0 ;;
-                edge|unstable)
-                    rel=1 ;;
-                *)
-                    echo "Error: release must be stable or edge."
-                    exit 1
-                    ;;
-            esac
-            shift; shift ;;
-        -c)
-            case "$2" in
-                cf)
-                    cli="cf" ;;
-                ltc)
-                    cli="ltc" ;;
-                *)
-                    echo "Error: cli must be either cf or ltc."
-                    exit 1
-                    ;;
-            esac
-            shift ; shift ;;
-        -p)
-            bindir="$2"
-            shift ; shift ;;
-        --)
-            shift ; break ;;
-    esac
-done    
-
-case $OSTYPE in
-    darwin*)
-        os="darwin"
-        if [ "cf" == $cli ] ; then cli_uri=${darwin_CF[rel]}; fi
-        if [ "ltc" == $cli ] ; then cli_uri=${darwin_LTC[rel]}; fi
-        ;;
-    linux*)
-        os="linux"
-        if [ "cf" == $cli ] ; then cli_uri=${linux_CF[rel]}; fi
-        if [ "ltc" == $cli ] ; then cli_url=${linux_LTC[rel]}; fi
-        ;;
-    *)
-        os="windows"
-        if [ "cf" == $cli ] ; then cli_uri=${linux_CF[rel]}; fi
-        if [ "ltc" == $cli ] ; then echo "Windows not supported by LTC" ; exit 1 ; fi
-esac
-
-# Save off old version, if any
-if [ -e $bindir/${cli}.old ] ; then
-    getver $bindir ${cli}.old
-    old_version=$version
-else
-    old_version="N/A"
-fi
-    
-echo "Downloading $cli_uri"
-cd /tmp
-case $cli in
-    cf)
-        getver ${bindir} cf
-        cur_version=$version
-        download $cli_uri $cli
-        tar xf cf-$$.bin
-        getver . cf
-        new_version=$version
-        ;;
-    ltc)
-        getver ${bindir} ltc
-        cur_version=$version
-        download $cli_uri $cli
-        mv $cli-$$.bin $cli
-        chmod a+rx $cli
-        getver . ltc
-        new_version=$version
-        ;;
-esac
-
-echo "Installing in $bindir"
-relink
-
-if [ "$old_version"X != "N/AX" ]; then echo "Old: ${old_version}: ${bindir}/${cli}.old"; fi
-echo "New: ${new_version}: ${bindir}/${cli}"
+printf "New Version:       "
+cf -v


### PR DESCRIPTION
Hi @goehmen,

I'm heading out for the week, and @mgoelzer will be taking over for me on Lattice. The real point of these scripts is that I was sick and tired of doing a lot of manual `ln -s` every time I downloaded a release candidate of `ltc`.

Probably the most important thing: When I realized just how off the deep-end I'd gone, I stopped using your `update-go-cli.sh` file and switched over to `update-cli.sh`. If I could, I'd revert your `update-go-cli.sh` all the way back to your fundamental helper script, but I'm not that much of a wizard with git.

I did recently upgrade the version-matching syntax to use sed instead of sh variable substitution. I think it's more reliable now. I didn't have a chance to add in the build-number/SHA into the filename, but if you want to, it should be pretty easy.

Oh, and there's a test suite. I promise I didn't do that during work hours!

This is a lot of code for relatively little functionality. I have no problem if you decide not to merge and just walk away. :)
